### PR TITLE
Fix ESLint errors by removing unused imports

### DIFF
--- a/bin/tts-mcp-server.ts
+++ b/bin/tts-mcp-server.ts
@@ -5,7 +5,6 @@ import 'dotenv/config';
 import { Command } from 'commander';
 import { startMcpServer } from '../src/mcp-server';
 import packageJson from '../package.json';
-import { promises as fs } from 'fs';
 import path from 'path';
 import { MCPServerConfig } from '../src/types';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { textToSpeech } from './api';
 import { readTextFile, ensureOutputDirectory, validateOptions, getOutputPath } from './utils';
-import { CommandLineOptions, OpenAIVoice, OpenAIOutputFormat, OpenAITTSModel } from './types';
+import { CommandLineOptions } from './types';
 
 /**
  * メインのアプリケーションロジック

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from 'fs';
-import nock from 'nock';
 import { OpenAI } from 'openai';
-import { TTSOptions, OpenAIVoice, OpenAIOutputFormat, OpenAITTSModel } from '../src/types';
+import { TTSOptions } from '../src/types';
 
 // モジュールをモック化
 jest.mock('openai');

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -2,7 +2,6 @@ import sinon from 'sinon';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { promises as fs } from 'fs';
-import path from 'path';
 import { OpenAI } from 'openai';
 import { startMcpServer, initializeClient } from '../src/mcp-server';
 import { MCPServerConfig } from '../src/types';


### PR DESCRIPTION
## 変更内容
ESLintで検出された未使用のインポートや変数を削除し、コードの品質を改善しました。

## 修正したファイル
- `bin/tts-mcp-server.ts`: 未使用の `fs` インポートを削除
- `src/index.ts`: 未使用の型 `OpenAIVoice`, `OpenAIOutputFormat`, `OpenAITTSModel` を削除
- `test/api.test.ts`: 未使用の `nock`, `OpenAIVoice`, `OpenAIOutputFormat`, `OpenAITTSModel` を削除
- `test/mcp-server.test.ts`: 未使用の `path` インポートを削除

## 検証内容
- ESLintでエラーがないことを確認
- テストがすべて正常に通過することを確認
- ビルドが問題なく完了することを確認

これにより、新たに導入したCIワークフローがスムーズに動作するようになります。